### PR TITLE
removed the unnecessary underline

### DIFF
--- a/app/(Home)/page.js
+++ b/app/(Home)/page.js
@@ -52,7 +52,7 @@ const page = () => {
                             <span className="text-white drop-shadow-2xl">
                                 Made <span className="relative">
                                     Simple
-                                    <div className="absolute -bottom-2 left-0 w-full h-1 bg-gradient-to-r from-blue-400 to-purple-400 rounded-full"></div>
+
                                 </span>
                             </span>
                         </h1>


### PR DESCRIPTION
This pull request removes an unnecessary horizontal line (<hr> / border / styled divider) that appeared under the main title on the Home Page.
The line did not fit well with the overall layout and visual design, so removing it improves the look and feel of the page.

**before**
<img width="1908" height="979" alt="Screenshot 2025-10-23 110119" src="https://github.com/user-attachments/assets/85808585-5176-46f5-a4f9-f212f09644c9" />

**After**
<img width="1908" height="1040" alt="image" src="https://github.com/user-attachments/assets/ced082db-ef0c-4ae7-8389-a93fb4466db5" />

